### PR TITLE
Add Redis worker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ docker-compose exec backend alembic revision --autogenerate -m "<message>"
 docker-compose exec backend alembic upgrade head
 ```
 
+## Background worker
+
+Matching jobs are processed by an RQ worker. Start it with Docker:
+
+```bash
+docker-compose up worker
+```
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,3 +11,11 @@ To create a new migration and apply it, run:
 docker-compose exec backend alembic revision --autogenerate -m "<message>"
 docker-compose exec backend alembic upgrade head
 ```
+
+## Running the worker
+
+Background tasks are processed using RQ. Start the worker with:
+
+```bash
+docker-compose up worker
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from sqlalchemy import func
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from fastapi.middleware.cors import CORSMiddleware
 
-from . import models, schemas, auth, database
+from . import models, schemas, auth, database, tasks
 
 models.Base.metadata.create_all(bind=database.engine)
 
@@ -111,6 +111,8 @@ def create_event(event: schemas.EventCreate, organizer: models.Organizer = Depen
     db.add(event_obj)
     db.commit()
     db.refresh(event_obj)
+    # Enqueue background matching task
+    tasks.enqueue_match_event(event_obj.id)
     return event_obj
 
 

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,18 @@
+import os
+from redis import Redis
+from rq import Queue
+
+# Configure Redis connection
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+redis_conn = Redis.from_url(redis_url)
+queue = Queue(connection=redis_conn)
+
+
+def match_event_to_users(event_id: int):
+    """Placeholder task that would match an event to interested users."""
+    print(f"Processing matching for event {event_id}")
+
+
+def enqueue_match_event(event_id: int):
+    """Helper to enqueue a matching job."""
+    queue.enqueue(match_event_to_users, event_id)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,0 +1,13 @@
+import os
+from redis import Redis
+from rq import Worker, Queue
+
+redis_url = os.getenv("REDIS_URL", "redis://redis:6379")
+listen = ["default"]
+conn = Redis.from_url(redis_url)
+
+
+if __name__ == "__main__":
+    queue = Queue(connection=conn)
+    worker = Worker([queue], connection=conn)
+    worker.work()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ sqlalchemy
 alembic
 python-jose[cryptography]
 passlib[bcrypt]
+redis
+rq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,17 @@ services:
     depends_on:
       - db
       - redis
+  worker:
+    build: ./backend
+    working_dir: /app
+    volumes:
+      - ./backend:/app
+    command: python -m app.worker
+    env_file:
+      - .env
+    depends_on:
+      - redis
+      - db
   db:
     image: postgres:15
     env_file:


### PR DESCRIPTION
## Summary
- add Redis-backed job queue using RQ
- enqueue matching jobs when creating events
- run worker service in Docker
- document how to start the worker

## Testing
- `python3 -m pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6886aa7aef1c832f9ab59c05d1cd44ea