### PR TITLE
Add CI workflow and developer utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=5
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend dependencies
+        run: |
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest
+
+      - name: Lint backend
+        run: |
+          cd backend
+          flake8 . --max-line-length 200 --extend-ignore=E302,E402,E305,W291,W293,W391,E128,E122
+
+      - name: Run backend tests
+        run: |
+          cd backend
+          pytest
+
+      - name: Build backend Docker image
+        run: docker build -t kinlia-backend ./backend
+
+      - name: Build frontend Docker image
+        run: docker build -t kinlia-frontend ./frontend

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: dev migrate worker
+
+dev:
+	docker-compose up
+
+migrate:
+	docker-compose exec backend alembic upgrade head
+
+worker:
+	docker-compose up worker

--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ Matching jobs are processed by an RQ worker. Start it with Docker:
 docker-compose up worker
 ```
 
+
+## Makefile
+
+Common commands are available via the Makefile:
+
+```bash
+make dev      # start all services
+make migrate  # apply migrations
+```
+
+## Continuous Integration
+
+A GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push and
+pull request. It installs dependencies, lints and tests the backend, and builds
+both Docker images to ensure they succeed.
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,4 +6,8 @@ python-jose[cryptography]
 passlib[bcrypt]
 redis
 rq
-pinecone-client
+pinecone
+flake8
+pytest
+email-validator
+python-multipart

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import app
+
+def test_app_exists():
+    assert app


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint, test and build
- provide a Makefile with common commands
- include minimal backend test
- document CI setup and Makefile usage in README
- update backend requirements

## Testing
- `pytest -q`
- `flake8 backend --max-line-length 200 --extend-ignore=E302,E402,E305,W291,W293,W391,E128,E122`
- `make -n dev`
- `make -n migrate`
- *(Building Docker images locally not possible: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6886af342808832fa9c4e00cc6342d0a