### PR TITLE
docs: add beginner-friendly README and next steps plan

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,0 +1,40 @@
+# Kinlia Next Steps & Implementation Plan
+
+This plan sketches where to take the project next. Each step is small on purpose so you can vibe your way through at your own pace.
+
+## 1. Explore the Running App
+- **What:** Start the Docker services and click around the app.
+- **Why:** Seeing it in action builds intuition before touching code.
+- **How:** `make dev` (or `docker-compose up`) from the project root.
+
+## 2. Polish the Onboarding Flow
+- **What:** Add friendly screens for sign up, log in and profile view.
+- **Why:** Good vibes start with a smooth first impression.
+- **Ideas:** Use simple forms, store the received token, show the user name.
+
+## 3. Build the Event Browser
+- **What:** Show a list of events and a detail page for each one.
+- **Why:** Events are the heart of Kinlia; the mobile app should make them easy to find.
+- **Ideas:** Fetch `/events` from the backend, display title, date and location.
+
+## 4. Implement Ticket Purchasing
+- **What:** Let a user tap "Buy" and post to `/events/{id}/tickets`.
+- **Why:** Buying a ticket is the main action users take.
+- **Ideas:** Confirm the purchase, then show the ticket in a "My Tickets" view.
+
+## 5. Organizer Dashboard (Optional)
+- **What:** Special screens for people who create events.
+- **Why:** Organizers need to see sales and manage their events.
+- **Ideas:** Use `/organizer/events` and `/organizer/events/{id}/tickets` endpoints.
+
+## 6. Add Background Matching Feedback
+- **What:** Surface results from the worker that matches people to events.
+- **Why:** Makes the app feel smart and personalized.
+- **Ideas:** Poll for updates or use push notifications when matches are ready.
+
+## 7. Hardening & Quality of Life
+- **What:** Sprinkle tests, error messages and comments everywhere.
+- **Why:** Future you (and collaborators) will thank you.
+- **Ideas:** Write backend `pytest` cases, run `flake8`, add loading spinners.
+
+Take these steps in whatever order feels fun. The goal is to keep shipping small pieces and learn as you go.

--- a/README.md
+++ b/README.md
@@ -1,61 +1,67 @@
-# kinlia
+# Kinlia
 
-Kinlia is a demo event management platform. It showcases a small FastAPI
-backend and an Expo powered React Native frontend working together through
-Docker.
+**Kinlia is a tiny event app built for vibes.** It blends a Python API and a mobile app so you can learn how the pieces of a modern stack talk to each other.
+
+This repo is friendly on purpose: the goal is to let you poke around, make small changes and see what happens.
+
+## Why these technologies?
+
+| Piece | Why it exists |
+|-------|---------------|
+| **FastAPI backend** | Python is easy to read and FastAPI gives you a web API with hardly any boilerplate. It also generates docs automatically so you can see and test the endpoints. |
+| **Expo + React Native frontend** | One set of JavaScript files runs on both iOS and Android. Expo handles the scary native tooling so you can focus on screens and styles. |
+| **Docker Compose** | Containers keep all services isolated. One command starts everything so you don't chase missing packages. |
+| **SQLite by default** | For learning you just need a file‑based database. When the app grows you can switch `DATABASE_URL` to Postgres without touching the code. |
+| **Redis + RQ worker** | Some jobs (like matching people to events) run in the background. A worker lets the API respond fast while heavy work happens elsewhere. |
+
+## Architecture in plain words
+
+```
+Frontend (Expo/React Native) ⇄ Backend API (FastAPI) ⇄ Database (SQLite/Postgres)
+                                       ↳ Background Worker (RQ + Redis)
+```
+
+1. The **frontend** asks the **backend** for data or sends user actions.
+2. The **backend** reads/writes the **database** and sometimes kicks off a background **worker** task.
+3. The worker can store extra data (like embeddings) and the cycle continues.
 
 ## Getting started
 
-1. Copy `.env.example` to `.env` and modify the values if needed.
-2. Install Docker and Docker Compose if they are not already available.
-3. Start all services with:
+1. **Install [Docker](https://www.docker.com/)**
+   - *Why:* It bundles all dependencies. No Python or Node installs needed.
+2. **Copy the example environment file**
+   - `cp .env.example .env`
+   - *Why:* Secrets and config live outside the code so you can change them without editing files.
+3. **Run the stack**
+   - `make dev` or `docker-compose up`
+   - *Why:* Spins up the API, the mobile dev server and the worker in one go.
+4. **Open the app**
+   - Visit [http://localhost:3412](http://localhost:3412) in a browser or the Expo Go app.
+   - The API is at [http://localhost:8194](http://localhost:8194).
+
+## Project layout
+
+```
+backend/   → FastAPI service (all the Python code)
+frontend/  → Expo React Native app (all the screens)
+shared/    → Placeholder for code used by both sides
+Makefile   → Handy shortcuts like `make dev`
+docker-compose.yml → Defines how the services run together
+```
+
+## Where to go next
+
+Ready to keep vibing? Check out the [Next Steps & Implementation Plan](NEXT_STEPS.md).
+
+## Testing
+
+Backend tests use `pytest` and live in `backend/tests`. Run them with:
 
 ```bash
-docker-compose up
+cd backend
+pytest
 ```
 
-The Expo server will be available on [http://localhost:3412](http://localhost:3412) and the FastAPI backend on [http://localhost:8194](http://localhost:8194).
+## Contributing
 
-## Directory Layout
-
-```
-backend/   # FastAPI service
-frontend/  # Expo React Native app
-shared/    # shared utilities (currently empty)
-docker-compose.yml
-Makefile
-```
-
-## Database migrations
-
-To create and apply database migrations run:
-
-```bash
-docker-compose exec backend alembic revision --autogenerate -m "<message>"
-docker-compose exec backend alembic upgrade head
-```
-
-## Background worker
-
-Matching jobs are processed by an RQ worker. Start it with Docker:
-
-```bash
-docker-compose up worker
-```
-
-
-## Makefile
-
-Common commands are available via the Makefile:
-
-```bash
-make dev      # start all services
-make migrate  # apply migrations
-```
-
-## Continuous Integration
-
-A GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push and
-pull request. It installs dependencies, lints and tests the backend, and builds
-both Docker images to ensure they succeed.
-
+Questions, ideas or feedback are welcome. Drop notes, open issues, or experiment in your own fork.


### PR DESCRIPTION
## Summary
- rewrite README with architecture reasoning and setup instructions for novice vibe coders
- add NEXT_STEPS.md outlining an implementation plan for the mobile app

## Testing
- `pip install -r backend/requirements.txt`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_b_68937ac90928832f948f5279d140a843